### PR TITLE
Set baseUrl to the internet site

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,0 +1,3 @@
+{
+  "baseUrl": "https://the-internet.herokuapp.com/login"
+}


### PR DESCRIPTION
### This PR Will:

Finish setting up my testing environment with the `baseURl` configured in the `cypress.json` file